### PR TITLE
Update: Only lock if user is STUDENT or MONITOR

### DIFF
--- a/backend/src/main/java/ct01/n06/backend/facade/AuthFacade.java
+++ b/backend/src/main/java/ct01/n06/backend/facade/AuthFacade.java
@@ -78,18 +78,20 @@ public class AuthFacade {
             String accessToken = jwtService.generateAccessToken(userEntity);
             String refreshToken = jwtService.generateRefreshToken(subject);
 
-            String redisKey = "user:" + subject + ":session";
+            if (isDeviceLockEnforced(userEntity)) {
+                String redisKey = "user:" + subject + ":session";
 
-            // Yêu cầu 2: Ràng buộc User - Session (Khóa tài khoản) - Xử lý đá session cũ hoặc từ chối login
-            Boolean locked = redisTemplate.opsForValue().setIfAbsent(
-                    redisKey,
-                    accessToken,
-                    refreshExpirationMs,
-                    TimeUnit.MILLISECONDS
-            );
+                // Chỉ khóa 1 thiết bị tại 1 thời điểm cho sinh viên.
+                Boolean locked = redisTemplate.opsForValue().setIfAbsent(
+                        redisKey,
+                        accessToken,
+                        refreshExpirationMs,
+                        TimeUnit.MILLISECONDS
+                );
 
-            if (!Boolean.TRUE.equals(locked)) {
-                throw new ForbiddenException("Tài khoản đang được đăng nhập trên thiết bị khác");
+                if (!Boolean.TRUE.equals(locked)) {
+                    throw new ForbiddenException("Tài khoản đang được đăng nhập trên thiết bị khác");
+                }
             }
 
             return LoginResponse.builder()
@@ -133,14 +135,16 @@ public class AuthFacade {
         String newAccessToken = jwtService.generateAccessToken(userEntity);
         String newRefreshToken = jwtService.generateRefreshToken(username);
 
-        // 2. PHẢI CẬP NHẬT LẠI ACCESS TOKEN MỚI VÀO REDIS
-        String redisKey = "user:" + username + ":session";
-        redisTemplate.opsForValue().set(
-                redisKey,
-                newAccessToken,
-                refreshExpirationMs,
-                TimeUnit.MILLISECONDS
-        );
+        if (isDeviceLockEnforced(userEntity)) {
+            // Chỉ duy trì khóa session trên Redis cho sinh viên.
+            String redisKey = "user:" + username + ":session";
+            redisTemplate.opsForValue().set(
+                    redisKey,
+                    newAccessToken,
+                    refreshExpirationMs,
+                    TimeUnit.MILLISECONDS
+            );
+        }
 
         return LoginResponse.builder()
                 .accessToken(newAccessToken)
@@ -156,6 +160,11 @@ public class AuthFacade {
         if ("ChangeThisDeviceSecretKey".equals(deviceHmacSecret.trim())) {
             log.warn("Cảnh báo: Đang dùng HMAC secret mặc định!");
         }
+    }
+
+    private boolean isDeviceLockEnforced(UserEntity user) {
+        return user != null
+                && (user.getRole() == Role.ROLE_STUDENT || user.getRole() == Role.ROLE_MONITOR);
     }
 
     public UserInfoResponse getCurrentUserInfo(Authentication authentication) {

--- a/backend/src/main/java/ct01/n06/backend/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/ct01/n06/backend/filter/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -62,33 +63,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // THÊM ĐIỀU KIỆN KIỂM TRA SecurityContextHolder ĐỂ TỐI ƯU
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             try {
-                // ==========================================
-                // 1. CHỐT CHẶN REDIS (KIỂM TRA 1 THIẾT BỊ)
-                // ==========================================
-                String redisKey = "user:" + username + ":session";
-                String tokenInRedis = (String) redisTemplate.opsForValue().get(redisKey);
-
-                // Nếu Redis không có token HOẶC token gửi lên khác với token trong Redis -> Bị đá!
-                if (tokenInRedis == null || !tokenInRedis.equals(jwt)) {
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                    response.setContentType("application/json");
-                    response.setCharacterEncoding("UTF-8");
-                    String errorJson = "{"
-                            + "\"success\": false, "
-                            + "\"message\": \"Tài khoản đã bị ngắt kết nối hoặc đăng nhập ở thiết bị khác.\", "
-                            + "\"type\": \"about:blank\", "
-                            + "\"title\": \"Unauthorized\", "
-                            + "\"detail\": \"Tài khoản đã bị ngắt kết nối hoặc đăng nhập ở thiết bị khác.\""
-                            + "}";
-                    response.getWriter().write(errorJson);
-                    return; // DỪNG LUỒNG CHẠY NGAY LẬP TỨC
-                }
-                // ==========================================
-
-
-                // 2. NẾU QUA ĐƯỢC REDIS -> TIẾP TỤC XÁC THỰC NHƯ BÌNH THƯỜNG
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
                 if (jwtService.isTokenValid(jwt, userDetails)) {
+                    if (isDeviceLockEnforced(userDetails)) {
+                        String redisKey = "user:" + username + ":session";
+                        String tokenInRedis = (String) redisTemplate.opsForValue().get(redisKey);
+
+                        // Sinh viên: Redis không có token hoặc lệch token => bị từ chối.
+                        if (tokenInRedis == null || !tokenInRedis.equals(jwt)) {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json");
+                            response.setCharacterEncoding("UTF-8");
+                            String errorJson = "{"
+                                    + "\"success\": false, "
+                                    + "\"message\": \"Tài khoản đã bị ngắt kết nối hoặc đăng nhập ở thiết bị khác.\", "
+                                    + "\"type\": \"about:blank\", "
+                                    + "\"title\": \"Unauthorized\", "
+                                    + "\"detail\": \"Tài khoản đã bị ngắt kết nối hoặc đăng nhập ở thiết bị khác.\""
+                                    + "}";
+                            response.getWriter().write(errorJson);
+                            return;
+                        }
+                    }
+
                     UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
                             userDetails,
                             null,
@@ -103,5 +100,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isDeviceLockEnforced(UserDetails userDetails) {
+        return userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(role -> "ROLE_STUDENT".equals(role) || "ROLE_MONITOR".equals(role));
     }
 }

--- a/backend/src/main/java/ct01/n06/backend/util/OAuth2LoginHandler.java
+++ b/backend/src/main/java/ct01/n06/backend/util/OAuth2LoginHandler.java
@@ -1,6 +1,7 @@
 package ct01.n06.backend.util;
 
 import ct01.n06.backend.entity.UserEntity;
+import ct01.n06.backend.entity.enums.Role;
 import ct01.n06.backend.security.JwtService;
 import ct01.n06.backend.service.DeviceSecurityService;
 import ct01.n06.backend.service.UserService;
@@ -65,18 +66,20 @@ public class OAuth2LoginHandler implements AuthenticationSuccessHandler, Authent
         String fallbackDeviceId = "oauth:" + userEntity.getId() + ":" + UUID.randomUUID();
         String deviceToken = deviceSecurityService.generateDeviceToken(fallbackDeviceId);
 
-        // Lưu access token vào Redis để đảm bảo 1 thiết bị/1 thời điểm
-        String redisKey = "user:" + userEntity.getUsername() + ":session";
-        Boolean locked = redisTemplate.opsForValue().setIfAbsent(redisKey, accessToken, refreshExpirationMs,
-                TimeUnit.MILLISECONDS);
-        if (!Boolean.TRUE.equals(locked)) {
-            String encodedMessage = URLEncoder.encode("SessionConflict", StandardCharsets.UTF_8);
-            String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUrl)
-                    .queryParam("error", encodedMessage)
-                    .build(true)
-                    .toUriString();
-            redirectStrategy.sendRedirect(request, response, targetUrl);
-            return;
+        if (isDeviceLockEnforced(userEntity)) {
+            // Chỉ sinh viên bị giới hạn 1 phiên đăng nhập.
+            String redisKey = "user:" + userEntity.getUsername() + ":session";
+            Boolean locked = redisTemplate.opsForValue().setIfAbsent(redisKey, accessToken, refreshExpirationMs,
+                    TimeUnit.MILLISECONDS);
+            if (!Boolean.TRUE.equals(locked)) {
+                String encodedMessage = URLEncoder.encode("SessionConflict", StandardCharsets.UTF_8);
+                String targetUrl = UriComponentsBuilder.fromUriString(frontendRedirectUrl)
+                        .queryParam("error", encodedMessage)
+                        .build(true)
+                        .toUriString();
+                redirectStrategy.sendRedirect(request, response, targetUrl);
+                return;
+            }
         }
 
         ResponseCookie deviceCookie = ResponseCookie.from(deviceCookieName, deviceToken)
@@ -121,5 +124,10 @@ public class OAuth2LoginHandler implements AuthenticationSuccessHandler, Authent
             return oAuth2User.getName();
         }
         return authentication.getName();
+    }
+
+    private boolean isDeviceLockEnforced(UserEntity userEntity) {
+        return userEntity != null
+                && (userEntity.getRole() == Role.ROLE_STUDENT || userEntity.getRole() == Role.ROLE_MONITOR);
     }
 }


### PR DESCRIPTION
This pull request introduces and applies device-based session locking for specific user roles (students and monitors), ensuring that only one active session per user is allowed for these roles. The enforcement is handled consistently across login, token refresh, OAuth2 login, and JWT authentication filter logic. The main changes are grouped below:

**Device Lock Enforcement Logic:**

* Added the `isDeviceLockEnforced` helper method in `AuthFacade`, `JwtAuthenticationFilter`, and `OAuth2LoginHandler` to check if the current user is a student or monitor, and only enforce single-device session locking for those roles. [[1]](diffhunk://#diff-0c36685469c6176b0d36c7cbdd4e63a792a2ec9428728c2399f1cc413d6c23d3R165-R169) [[2]](diffhunk://#diff-958324b3133b946e4c8dbc07487a007c1a007e76be89cdfcedaab70562f06404R104-R109) [[3]](diffhunk://#diff-53dcf234dd72b2c1d1163b254a548515ed4e608fb6a73909d009d50de4957f8dR128-R132)

**Login and Token Refresh:**

* Updated the login flow in `AuthFacade` to enforce single-device session locking only for students and monitors, throwing a `ForbiddenException` if an existing session is detected. [[1]](diffhunk://#diff-0c36685469c6176b0d36c7cbdd4e63a792a2ec9428728c2399f1cc413d6c23d3R81-R84) [[2]](diffhunk://#diff-0c36685469c6176b0d36c7cbdd4e63a792a2ec9428728c2399f1cc413d6c23d3R95)
* Modified the token refresh logic to update the Redis session only for users with device lock enforced, maintaining session integrity for students and monitors.

**OAuth2 Login:**

* Updated `OAuth2LoginHandler` to enforce device lock in the OAuth2 login flow, restricting students to one active session at a time. [[1]](diffhunk://#diff-53dcf234dd72b2c1d1163b254a548515ed4e608fb6a73909d009d50de4957f8dL68-R70) [[2]](diffhunk://#diff-53dcf234dd72b2c1d1163b254a548515ed4e608fb6a73909d009d50de4957f8dR83)

**JWT Authentication Filter:**

* Enhanced the JWT authentication filter to check Redis for a valid session token only for users with device lock enforced, and to reject requests with missing or mismatched tokens for those roles. [[1]](diffhunk://#diff-958324b3133b946e4c8dbc07487a007c1a007e76be89cdfcedaab70562f06404L65-R72) [[2]](diffhunk://#diff-958324b3133b946e4c8dbc07487a007c1a007e76be89cdfcedaab70562f06404L84-L91)
* Refactored imports and minor code cleanup to support the new logic. [[1]](diffhunk://#diff-958324b3133b946e4c8dbc07487a007c1a007e76be89cdfcedaab70562f06404R13) [[2]](diffhunk://#diff-53dcf234dd72b2c1d1163b254a548515ed4e608fb6a73909d009d50de4957f8dR4)

These changes ensure that device-based session restrictions are only applied to students and monitors, improving both security and user experience for other roles.